### PR TITLE
Convert ci-pipeline-poll-scm to GitHub Actions

### DIFF
--- a/.github/workflows/ci-pipeline-poll-scm.yml
+++ b/.github/workflows/ci-pipeline-poll-scm.yml
@@ -51,20 +51,6 @@ jobs:
         format: ALL
         out: reports
         args: "--failOnCVSS 9"
-#     # This item has no matching transformer
-#     - dependencyCheckPublisher:
-#       - key: failedTotalCritical
-#         value:
-#           isLiteral: true
-#           value: 1
-#       - key: pattern
-#         value:
-#           isLiteral: true
-#           value: dependency-check-report.xml
-#       - key: stopBuild
-#         value:
-#           isLiteral: true
-#           value: true
   Unit_Testing:
     name: Unit Testing
     runs-on:
@@ -84,7 +70,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4
     - name: install dependencies
-      uses: npm install --no-audit
+      run: npm install --no-audit
     - uses: nick-fields/retry@v3
       with:
         timeout_minutes: 60


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/ci-pipeline-poll-scm) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ci-pipeline-poll-scm
- [ ] Ensure secret is available: `${{ secrets.mongo-db-password }}`
- [ ] Ensure build tool is available: `nodejs`