### PR TITLE
Convert ci-pipeline-poll-scm to GitHub Actions

### DIFF
--- a/.github/workflows/ci-pipeline-poll-scm.yml
+++ b/.github/workflows/ci-pipeline-poll-scm.yml
@@ -8,7 +8,7 @@ on:
 env:
   MONGO_URI: mongodb+srv://supercluster.d83jj.mongodb.net/superData
   MONGO_USERNAME: superuser
-  MONGO_PASSWORD: "${{ secrets.mongo-db-password }}"
+  MONGO_PASSWORD: "${{ secrets.mongo_db_password }}"
 jobs:
   Installing_Dependencies:
     name: Installing Dependencies


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/ci-pipeline-poll-scm) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ci-pipeline-poll-scm
- [x] Ensure secret is available: `${{ secrets.mongo_db_password }}`
- [x] Ensure build tool is available: `nodejs`