### PR TITLE
Convert ci-pipeline-poll-scm to GitHub Actions

### DIFF
--- a/.github/workflows/ci-pipeline-poll-scm.yml
+++ b/.github/workflows/ci-pipeline-poll-scm.yml
@@ -119,8 +119,8 @@ jobs:
         name: Code Coverage HTML Report
         path: coverage/lcov-report/
         retention-days: 30
-  Build_Plublish_Image:
-    name: Build Plublish Image
+  Build_Image:
+    name: Build Image
     runs-on:
       - ubuntu-latest
     needs: Code_Coverage
@@ -128,23 +128,13 @@ jobs:
     - name: checkout
       uses: actions/checkout@v4.1.0
     - name: Build Docker image
-      run: docker build -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME  }}:${{ github.sha }} .
+      run: docker build -t ${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME }}:${{ github.sha }} .
       shell: bash
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: "${{ vars.DOCKERHUB_USERNAME }}"
-        password: "${{ secrets.DOCKERHUB_PASSWORD }}"
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      with:
-        push: true
-        tags: "${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME  }}:${{ github.sha }}"
   Trivy_Vulnerability_Scanner:
     name: Trivy Vulnerability Scanner
     runs-on:
       - ubuntu-latest
-    needs: Build_Plublish_Image
+    needs: Build_Image
     steps:
     - name: checkout
       uses: actions/checkout@v4.1.0
@@ -164,3 +154,21 @@ jobs:
       with:
         name: Trivy Report
         path: trivy-results.html
+  Push_Docker_Image:
+    name: Push Docker Image
+    runs-on:
+      - ubuntu-latest
+    needs: Trivy_Vulnerability_Scanner
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: "${{ vars.DOCKERHUB_USERNAME }}"
+        password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        tags: "${{ vars.DOCKERHUB_USERNAME }}/${{ vars.IMAGE_NAME  }}:${{ github.sha }}"


### PR DESCRIPTION
Pipeline migrated from [Jenkins](http://139.84.149.83:8080/job/ci-pipeline-poll-scm) :tada:

## Manual steps

Perform the following steps to complete the migration:

### ci-pipeline-poll-scm
- [ ] Ensure secret is available: `${{ secrets.mongo_db_password }}`
- [ ] Ensure build tool is available: `nodejs`